### PR TITLE
deduplicate and increase block size more

### DIFF
--- a/create-conty.sh
+++ b/create-conty.sh
@@ -21,9 +21,7 @@ squashfs_compressor_arguments=(-b 1M -comp ${squashfs_compressor} -Xcompression-
 
 # Use DwarFS instead of SquashFS
 dwarfs="true"
-dwarfs_compressor_arguments=(-l7 -C zstd:level=22 --metadata-compression null \
-                            -S 24 -B 2 --order nilsimsa \
-                            -W 12 -w 4 --no-create-timestamp)
+dwarfs_compressor_arguments=(-l7 -C zstd:level=22 -S 25 -B 3 --no-create-timestamp)
 
 # Set to true to use an existing image if it exists
 # Otherwise the script will always create a new image


### PR DESCRIPTION
This made the Steam appimage 337 MiB. 

It can be made smaller but that means switching to 64 MiB blocks and using lzma compression, which will likely hurt performance noticeably. 